### PR TITLE
Make pi-blaster work on Pi2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
 
+#CFLAGS = -DDEBUG -Wall -pedantic
 CFLAGS = -Wall -pedantic
 EXTRA_DIST = pi-blaster.service
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
 
-#CFLAGS = -DDEBUG -Wall -pedantic
+#CFLAGS = -g -DDEBUG -Wall -pedantic
 CFLAGS = -Wall -pedantic
 EXTRA_DIST = pi-blaster.service
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ CFLAGS = -Wall -pedantic
 EXTRA_DIST = pi-blaster.service
 
 sbin_PROGRAMS = pi-blaster
-pi_blaster_SOURCES = pi-blaster.c
+pi_blaster_SOURCES = pi-blaster.c mailbox.c
 
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = pi-blaster.service

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Pete Nelson (https://github.com/petiepooo)
 Edgar Siva (https://github.com/edgarsilva)
 Alex Lennon (https://github.com/ajlennon)
 Lara Maia (https://github.com/LaraCraft304)
+Pattrick Hüper (https://github.com/phueper)
 
 ## Want to support this project?
 

--- a/mailbox.c
+++ b/mailbox.c
@@ -1,0 +1,244 @@
+/*
+Copyright (c) 2012, Broadcom Europe Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+
+#include "mailbox.h"
+
+#define PAGE_SIZE (4*1024)
+
+void *mapmem(unsigned base, unsigned size)
+{
+   int mem_fd;
+   unsigned offset = base % PAGE_SIZE;
+   base = base - offset;
+   /* open /dev/mem */
+   if ((mem_fd = open("/dev/mem", O_RDWR|O_SYNC) ) < 0) {
+      printf("can't open /dev/mem\nThis program should be run as root. Try prefixing command with: sudo\n");
+      exit (-1);
+   }
+   void *mem = mmap(
+      0,
+      size,
+      PROT_READ|PROT_WRITE,
+      MAP_SHARED/*|MAP_FIXED*/,
+      mem_fd,
+      base);
+#ifdef DEBUG
+   printf("base=0x%x, mem=%p\n", base, mem);
+#endif
+   if (mem == MAP_FAILED) {
+      printf("mmap error %d\n", (int)mem);
+      exit (-1);
+   }
+   close(mem_fd);
+   return (char *)mem + offset;
+}
+
+void *unmapmem(void *addr, unsigned size)
+{
+   int s = munmap(addr, size);
+   if (s != 0) {
+      printf("munmap error %d\n", s);
+      exit (-1);
+   }
+
+   return NULL;
+}
+
+/*
+ * use ioctl to send mbox property message
+ */
+
+static int mbox_property(int file_desc, void *buf)
+{
+   int ret_val = ioctl(file_desc, IOCTL_MBOX_PROPERTY, buf);
+
+   if (ret_val < 0) {
+      printf("ioctl_set_msg failed:%d\n", ret_val);
+   }
+
+#ifdef DEBUG
+   unsigned *p = buf; int i; unsigned size = *(unsigned *)buf;
+   for (i=0; i<size/4; i++)
+      printf("%04x: 0x%08x\n", i*sizeof *p, p[i]);
+#endif
+   return ret_val;
+}
+
+unsigned mem_alloc(int file_desc, unsigned size, unsigned align, unsigned flags)
+{
+   int i=0;
+   unsigned p[32];
+printf("Requesting %d bytes\n", size);
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x3000c; // (the tag id)
+   p[i++] = 12; // (size of the buffer)
+   p[i++] = 12; // (size of the data)
+   p[i++] = size; // (num bytes? or pages?)
+   p[i++] = align; // (alignment)
+   p[i++] = flags; // (MEM_FLAG_L1_NONALLOCATING)
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+
+   mbox_property(file_desc, p);
+   return p[5];
+}
+
+unsigned mem_free(int file_desc, unsigned handle)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x3000f; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 4; // (size of the data)
+   p[i++] = handle;
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+
+   mbox_property(file_desc, p);
+   return p[5];
+}
+
+unsigned mem_lock(int file_desc, unsigned handle)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x3000d; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 4; // (size of the data)
+   p[i++] = handle;
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+
+   mbox_property(file_desc, p);
+   return p[5];
+}
+
+unsigned mem_unlock(int file_desc, unsigned handle)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x3000e; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 4; // (size of the data)
+   p[i++] = handle;
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+
+   mbox_property(file_desc, p);
+   return p[5];
+}
+
+unsigned execute_code(int file_desc, unsigned code, unsigned r0, unsigned r1, unsigned r2, unsigned r3, unsigned r4, unsigned r5)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x30010; // (the tag id)
+   p[i++] = 28; // (size of the buffer)
+   p[i++] = 28; // (size of the data)
+   p[i++] = code;
+   p[i++] = r0;
+   p[i++] = r1;
+   p[i++] = r2;
+   p[i++] = r3;
+   p[i++] = r4;
+   p[i++] = r5;
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+
+   mbox_property(file_desc, p);
+   return p[5];
+}
+
+unsigned qpu_enable(int file_desc, unsigned enable)
+{
+   int i=0;
+   unsigned p[32];
+
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x30012; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 4; // (size of the data)
+   p[i++] = enable;
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+
+   mbox_property(file_desc, p);
+   return p[5];
+}
+
+unsigned execute_qpu(int file_desc, unsigned num_qpus, unsigned control, unsigned noflush, unsigned timeout) {
+   int i=0;
+   unsigned p[32];
+
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+   p[i++] = 0x30011; // (the tag id)
+   p[i++] = 16; // (size of the buffer)
+   p[i++] = 16; // (size of the data)
+   p[i++] = num_qpus;
+   p[i++] = control;
+   p[i++] = noflush;
+   p[i++] = timeout; // ms
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+
+   mbox_property(file_desc, p);
+   return p[5];
+}

--- a/mailbox.c
+++ b/mailbox.c
@@ -320,3 +320,22 @@ unsigned get_board_revision(int file_desc)
 //   }
    return p[5];
 }
+
+unsigned get_dma_channels(int file_desc)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x60001; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 0; // (size of the data)
+   p[i++] = 0; // response buffer
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+   
+   mbox_property(file_desc, p);
+   return p[5];
+}

--- a/mailbox.c
+++ b/mailbox.c
@@ -88,6 +88,13 @@ void *unmapmem(void *addr, unsigned size)
 
 static int mbox_property(int file_desc, void *buf)
 {
+#ifdef DEBUG
+   unsigned *p = buf; int i; unsigned size = *(unsigned *)buf;
+   printf("MBox Request:\n");
+   for (i=0; i<size/sizeof *p; i++)
+      printf("%04x: 0x%08x\n", i*sizeof *p, p[i]);
+#endif
+
    int ret_val = ioctl(file_desc, IOCTL_MBOX_PROPERTY, buf);
 
    if (ret_val < 0) {
@@ -96,7 +103,8 @@ static int mbox_property(int file_desc, void *buf)
 
 #ifdef DEBUG
    // TODO: check return code in p[1]==0x80000000, otherwise... error
-   unsigned *p = buf; int i; unsigned size = *(unsigned *)buf;
+   p = buf; size = *(unsigned *)buf;
+   printf("MBox Response:\n");
    for (i=0; i<size/sizeof *p; i++)
       printf("%04x: 0x%08x\n", i*sizeof *p, p[i]);
 #endif
@@ -108,6 +116,8 @@ unsigned mem_alloc(int file_desc, unsigned size, unsigned align, unsigned flags)
    int i=0;
    unsigned p[32];
 dprintf("Requesting %d bytes\n", size);
+dprintf("Alignment: %d bytes\n", align);
+dprintf("mem_alloc flags:  0x%x\n", flags);
    p[i++] = 0; // size
    p[i++] = 0x00000000; // process request
 

--- a/mailbox.c
+++ b/mailbox.c
@@ -37,6 +37,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "mailbox.h"
 
+#ifdef DEBUG
+#define dprintf(args...) printf(args)
+#else
+#define dprintf(args...)
+#endif
+
 #define PAGE_SIZE (4*1024)
 
 void *mapmem(unsigned base, unsigned size)
@@ -56,9 +62,7 @@ void *mapmem(unsigned base, unsigned size)
       MAP_SHARED/*|MAP_FIXED*/,
       mem_fd,
       base);
-#ifdef DEBUG
-   printf("base=0x%x, mem=%p\n", base, mem);
-#endif
+   dprintf("base=0x%x, mem=%p\n", base, mem);
    if (mem == MAP_FAILED) {
       printf("mmap error %d\n", (int)mem);
       exit (-1);
@@ -103,7 +107,7 @@ unsigned mem_alloc(int file_desc, unsigned size, unsigned align, unsigned flags)
 {
    int i=0;
    unsigned p[32];
-printf("Requesting %d bytes\n", size);
+dprintf("Requesting %d bytes\n", size);
    p[i++] = 0; // size
    p[i++] = 0x00000000; // process request
 

--- a/mailbox.c
+++ b/mailbox.c
@@ -25,6 +25,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+/* this is a modified version of the file found at: https://github.com/raspberrypi/userland/blob/master/host_applications/linux/apps/hello_pi/hello_fft/mailbox.c */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/mailbox.c
+++ b/mailbox.c
@@ -242,3 +242,73 @@ unsigned execute_qpu(int file_desc, unsigned num_qpus, unsigned control, unsigne
    mbox_property(file_desc, p);
    return p[5];
 }
+
+unsigned get_firmware_revision(int file_desc)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x10000; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 0; // (size of the data)
+   p[i++] = 0; // response buffer
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+   
+   mbox_property(file_desc, p);
+   return p[5];
+}
+
+unsigned get_board_model(int file_desc)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x10001; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 0; // (size of the data)
+   p[i++] = 0; // response buffer
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+   
+   mbox_property(file_desc, p);
+   // TODO: check return code in p[1]==0x80000000, otherwise... error
+//    printf("get_board_model mbox response buffer:\n");
+//    int pi = 0;
+//    int length = p[0]/sizeof *p;
+//   for (; pi < length; pi++) {
+//        printf("%d: %#x\n", pi, p[pi]);
+//   }
+   return p[5];
+}
+
+unsigned get_board_revision(int file_desc)
+{
+   int i=0;
+   unsigned p[32];
+   p[i++] = 0; // size
+   p[i++] = 0x00000000; // process request
+
+   p[i++] = 0x10002; // (the tag id)
+   p[i++] = 4; // (size of the buffer)
+   p[i++] = 0; // (size of the data)
+   p[i++] = 0; // response buffer
+
+   p[i++] = 0x00000000; // end tag
+   p[0] = i*sizeof *p; // actual size
+   
+   mbox_property(file_desc, p);
+//    printf("get_board_revision mbox response buffer:\n");
+//    int pi = 0;
+//    int length = p[0]/sizeof *p;
+//   for (; pi < length; pi++) {
+//        printf("%d: %#x\n", pi, p[pi]);
+//   }
+   return p[5];
+}

--- a/mailbox.c
+++ b/mailbox.c
@@ -91,8 +91,9 @@ static int mbox_property(int file_desc, void *buf)
    }
 
 #ifdef DEBUG
+   // TODO: check return code in p[1]==0x80000000, otherwise... error
    unsigned *p = buf; int i; unsigned size = *(unsigned *)buf;
-   for (i=0; i<size/4; i++)
+   for (i=0; i<size/sizeof *p; i++)
       printf("%04x: 0x%08x\n", i*sizeof *p, p[i]);
 #endif
    return ret_val;
@@ -278,13 +279,6 @@ unsigned get_board_model(int file_desc)
    p[0] = i*sizeof *p; // actual size
    
    mbox_property(file_desc, p);
-   // TODO: check return code in p[1]==0x80000000, otherwise... error
-//    printf("get_board_model mbox response buffer:\n");
-//    int pi = 0;
-//    int length = p[0]/sizeof *p;
-//   for (; pi < length; pi++) {
-//        printf("%d: %#x\n", pi, p[pi]);
-//   }
    return p[5];
 }
 

--- a/mailbox.h
+++ b/mailbox.h
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2012, Broadcom Europe Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <linux/ioctl.h>
+
+#define MAJOR_NUM 100
+#define IOCTL_MBOX_PROPERTY _IOWR(MAJOR_NUM, 0, char *)
+
+unsigned get_version(int file_desc);
+unsigned mem_alloc(int file_desc, unsigned size, unsigned align, unsigned flags);
+unsigned mem_free(int file_desc, unsigned handle);
+unsigned mem_lock(int file_desc, unsigned handle);
+unsigned mem_unlock(int file_desc, unsigned handle);
+void *mapmem(unsigned base, unsigned size);
+void *unmapmem(void *addr, unsigned size);
+
+unsigned execute_code(int file_desc, unsigned code, unsigned r0, unsigned r1, unsigned r2, unsigned r3, unsigned r4, unsigned r5);
+unsigned execute_qpu(int file_desc, unsigned num_qpus, unsigned control, unsigned noflush, unsigned timeout);
+unsigned qpu_enable(int file_desc, unsigned enable);

--- a/mailbox.h
+++ b/mailbox.h
@@ -25,10 +25,23 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifndef _PIBLASTER_MAILBOX_H
+#define _PIBLASTER_MAILBOX_H
+ 
 #include <linux/ioctl.h>
 
 #define MAJOR_NUM 100
 #define IOCTL_MBOX_PROPERTY _IOWR(MAJOR_NUM, 0, char *)
+
+/* from https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface */
+#define MEM_FLAG_DISCARDABLE (1 << 0) /* can be resized to 0 at any time. Use for cached data */
+#define MEM_FLAG_NORMAL (0 << 2) /* normal allocating alias. Don't use from ARM */
+#define MEM_FLAG_DIRECT (1 << 2) /* 0xC alias uncached */
+#define MEM_FLAG_COHERENT (2 << 2) /* 0x8 alias. Non-allocating in L2 but coherent */
+#define MEM_FLAG_L1_NONALLOCATING (MEM_FLAG_DIRECT | MEM_FLAG_COHERENT) /* Allocating in L2 */
+#define MEM_FLAG_ZERO (1 << 4)  /* initialise buffer to all zeros */
+#define MEM_FLAG_NO_INIT (1 << 5) /* don't initialise (default is initialise to all ones */
+#define MEM_FLAG_HINT_PERMALOCK (1 << 6) /* Likely to be locked for long periods of time. */
 
 unsigned get_version(int file_desc);
 unsigned mem_alloc(int file_desc, unsigned size, unsigned align, unsigned flags);
@@ -41,3 +54,9 @@ void *unmapmem(void *addr, unsigned size);
 unsigned execute_code(int file_desc, unsigned code, unsigned r0, unsigned r1, unsigned r2, unsigned r3, unsigned r4, unsigned r5);
 unsigned execute_qpu(int file_desc, unsigned num_qpus, unsigned control, unsigned noflush, unsigned timeout);
 unsigned qpu_enable(int file_desc, unsigned enable);
+
+unsigned get_firmware_revision(int file_desc);
+unsigned get_board_model(int file_desc);
+unsigned get_board_revision(int file_desc);
+
+#endif /* ifndef _PIBLASTER_MAILBOX_H */

--- a/mailbox.h
+++ b/mailbox.h
@@ -58,5 +58,6 @@ unsigned qpu_enable(int file_desc, unsigned enable);
 unsigned get_firmware_revision(int file_desc);
 unsigned get_board_model(int file_desc);
 unsigned get_board_revision(int file_desc);
+unsigned get_dma_channels(int file_desc);
 
 #endif /* ifndef _PIBLASTER_MAILBOX_H */

--- a/mailbox.h
+++ b/mailbox.h
@@ -25,6 +25,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+/* this is a modified version of the file found at: https://github.com/raspberrypi/userland/blob/master/host_applications/linux/apps/hello_pi/hello_fft/mailbox.h */
+
 #ifndef _PIBLASTER_MAILBOX_H
 #define _PIBLASTER_MAILBOX_H
  

--- a/pi-blaster.c
+++ b/pi-blaster.c
@@ -896,6 +896,8 @@ main(int argc, char **argv)
 	unsigned mbox_board_rev = get_board_revision(mbox.handle);
 	printf("MBox Board Revision: %#x\n", mbox_board_rev);
 	get_model(mbox_board_rev);
+	unsigned mbox_dma_channels = get_dma_channels(mbox.handle);
+	printf("DMA Channels Info: %#x, using DMA Channel: %d\n", mbox_dma_channels, DMA_CHAN_NUM);
 
 	printf("Using hardware:                 %5s\n", delay_hw == DELAY_VIA_PWM ? "PWM" : "PCM");
 	printf("Number of channels:             %5d\n", NUM_CHANNELS);

--- a/pi-blaster.c
+++ b/pi-blaster.c
@@ -40,15 +40,15 @@ static char VERSION[] = "0.1.1";
 // Created new known_pins with raspberry pi list of pins
 // to compare against the param received.
 static uint8_t known_pins[] = {
-        4,      // P1-7
-        17,     // P1-11
-        18,     // P1-12
-        27,     // P1-13
-        21,     // P1-13
-        22,     // P1-15
-        23,     // P1-16
-        24,     // P1-18
-        25,     // P1-22
+		4,      // P1-7
+		17,     // P1-11
+		18,     // P1-12
+		27,     // P1-13
+		21,     // P1-13
+		22,     // P1-15
+		23,     // P1-16
+		24,     // P1-18
+		25,     // P1-22
 };
 
 // pin2gpio array is not setup as empty to avoid locking all GPIO
@@ -235,6 +235,7 @@ terminate(int dummy)
 	unlink(DEVFILE);
 	printf("Unlink %s...\n", DEVFILE_MBOX);
 	unlink(DEVFILE_MBOX);
+	printf("pi-blaster stopped.\n");
 
 	exit(1);
 }
@@ -324,10 +325,10 @@ is_known_pin(int pin){
 
   int i;
   for (i = 0; i < LENGTH(known_pins); i++) { //NUM_CHANNELS
-    if (known_pins[i] == pin) {
-      found = 1;
-      break;
-    }
+	if (known_pins[i] == pin) {
+	  found = 1;
+	  break;
+	}
   }
   return(found);
 }
@@ -341,16 +342,16 @@ set_pin2gpio(int pin, float width){
 
   int i;
   for (i = 0; i < NUM_CHANNELS; i++) {
-    if (pin2gpio[i] == pin || pin2gpio[i] == 0) {
-      if (pin2gpio[i] == 0) {
-        gpio_set(pin, invert_mode);
-        gpio_set_mode(pin, GPIO_MODE_OUT);
-      }
-      pin2gpio[i] = pin;
-      channel_pwm[i] = width;
-      established = 1;
-      break;
-    }
+	if (pin2gpio[i] == pin || pin2gpio[i] == 0) {
+	  if (pin2gpio[i] == 0) {
+		gpio_set(pin, invert_mode);
+		gpio_set_mode(pin, GPIO_MODE_OUT);
+	  }
+	  pin2gpio[i] = pin;
+	  channel_pwm[i] = width;
+	  established = 1;
+	  break;
+	}
   }
 
   return(established);
@@ -365,15 +366,15 @@ compact_pin2gpio(){
   float tmp_channel_pwm[] = { 0,0,0,0,0,0,0,0 };
 
   for (i = 0; i < NUM_CHANNELS; i++) {
-    if (pin2gpio[i] != 0){
-      tmp_pin2gpio[j] = pin2gpio[i];
-      tmp_channel_pwm[j] = channel_pwm[i];
-      j++;
-    }
+	if (pin2gpio[i] != 0){
+	  tmp_pin2gpio[j] = pin2gpio[i];
+	  tmp_channel_pwm[j] = channel_pwm[i];
+	  j++;
+	}
   }
   for (i= 0 ;i < NUM_CHANNELS; i++){
-    pin2gpio[i] = tmp_pin2gpio[i];
-    channel_pwm[i] = tmp_channel_pwm[i];
+	pin2gpio[i] = tmp_pin2gpio[i];
+	channel_pwm[i] = tmp_channel_pwm[i];
   }
 }
 
@@ -387,12 +388,12 @@ release_pin2gpio(int pin)
 
   int i;
   for (i = 0; i < NUM_CHANNELS; i++) {
-    if (pin2gpio[i] == pin) {
-      channel_pwm[i] = 0;
-      pin2gpio[i] = 0;
-      released = 1;
-      break;
-    }
+	if (pin2gpio[i] == pin) {
+	  channel_pwm[i] = 0;
+	  pin2gpio[i] = 0;
+	  released = 1;
+	  break;
+	}
   }
 
   compact_pin2gpio();
@@ -405,9 +406,9 @@ static void
 set_pin(int pin, float width)
 {
   if (is_known_pin(pin)){
-    set_pin2gpio(pin, width);
+	set_pin2gpio(pin, width);
   }else{
-    fprintf(stderr, "Not a known pin for pi-blaster\n");
+	fprintf(stderr, "Not a known pin for pi-blaster\n");
   }
 }
 
@@ -417,9 +418,9 @@ static void
 release_pin(int pin)
 {
   if (is_known_pin(pin)){
-    release_pin2gpio(pin);
+	release_pin2gpio(pin);
   }else{
-    fprintf(stderr, "Not a known pin for pi-blaster\n");
+	fprintf(stderr, "Not a known pin for pi-blaster\n");
   }
 }
 
@@ -476,7 +477,7 @@ update_pwm()
 	/*   Now create a mask of all the pins that should be on */
 	mask = 0;
 	for (i = 0; i < NUM_CHANNELS; i++) {
-    // Check the pin2gpio pin has been set to avoid locking all of them as PWM.
+	// Check the pin2gpio pin has been set to avoid locking all of them as PWM.
 		if (channel_pwm[i] > 0 && pin2gpio[i]) {
 			mask |= 1 << pin2gpio[i];
 		}
@@ -492,7 +493,7 @@ update_pwm()
 			ctl->cb[j*2].dst = phys_gpclr0;
 		mask = 0;
 		for (i = 0; i < NUM_CHANNELS; i++) {
-      // Check the pin2gpio pin has been set to avoid locking all of them as PWM.
+	  // Check the pin2gpio pin has been set to avoid locking all of them as PWM.
 			if ((float)j/NUM_SAMPLES > channel_pwm[i] && pin2gpio[i])
 				mask |= 1 << pin2gpio[i];
 		}
@@ -519,12 +520,9 @@ setup_sighandlers(void)
 static void
 init_ctrl_data(void)
 {
-    printf("Initializing DMA Control...\n");
-printf("1\n");
+	printf("Initializing DMA Control...\n");
 	struct ctl *ctl = (struct ctl *)mbox.virt_addr;
-printf("1\n");
 	dma_cb_t *cbp = ctl->cb;
-printf("1\n");
 	uint32_t phys_fifo_addr;
 	uint32_t phys_gpclr0 = 0x7e200000 + 0x28;
 	uint32_t phys_gpset0 = 0x7e200000 + 0x1c;
@@ -535,13 +533,12 @@ printf("1\n");
 		phys_fifo_addr = (PWM_BASE | 0x7e000000) + 0x18;
 	else
 		phys_fifo_addr = (PCM_BASE | 0x7e000000) + 0x04;
-printf("1\n");
 	memset(ctl->sample, 0, sizeof(ctl->sample));
 
 	// Calculate a mask to turn off all the servos
 	mask = 0;
 	for (i = 0; i < NUM_CHANNELS; i++){
-    mask |= 1 << known_pins[i];
+	mask |= 1 << known_pins[i];
   }
 	for (i = 0; i < NUM_SAMPLES; i++)
 		ctl->sample[i] = mask;
@@ -551,27 +548,18 @@ printf("1\n");
 	 *    address which can be either the gpclr0 register or the gpset0 register
 	 *  - 2nd command waits for a trigger from an external source (PWM or PCM)
 	 */
-printf("1\n");
 	for (i = 0; i < NUM_SAMPLES; i++) {
-printf("i: %d, cbp: %p\n", i, (void *)cbp);
 		/* First DMA command */
 		cbp->info = DMA_NO_WIDE_BURSTS | DMA_WAIT_RESP;
-printf("ctl->sample: %p\n", (void *)ctl->sample);
 		cbp->src = mem_virt_to_phys(ctl->sample + i);
-printf("2\n");
 		if (invert_mode)
 			cbp->dst = phys_gpset0;
 		else
 			cbp->dst = phys_gpclr0;
-printf("2\n");
 		cbp->length = 4;
-printf("2\n");
 		cbp->stride = 0;
-printf("2\n");
 		cbp->next = mem_virt_to_phys(cbp + 1);
-printf("2\n");
 		cbp++;
-printf("2\n");
 		/* Second DMA command */
 		if (delay_hw == DELAY_VIA_PWM)
 			cbp->info = DMA_NO_WIDE_BURSTS | DMA_WAIT_RESP | DMA_D_DREQ | DMA_PER_MAP(5);
@@ -583,18 +571,16 @@ printf("2\n");
 		cbp->stride = 0;
 		cbp->next = mem_virt_to_phys(cbp + 1);
 		cbp++;
-printf("2\n");
 	}
 	cbp--;
 	cbp->next = mem_virt_to_phys(ctl->cb);
-	printf("1\n");
 }
 
 static void
 init_hardware(void)
 {
-    printf("Initializing PWM HW...\n");
-    struct ctl *ctl = (struct ctl *)mbox.virt_addr;
+	printf("Initializing PWM HW...\n");
+	struct ctl *ctl = (struct ctl *)mbox.virt_addr;
 
 	if (delay_hw == DELAY_VIA_PWM) {
 		// Initialise PWM
@@ -654,7 +640,7 @@ init_pin2gpio(void)
 {
   int i;
   for (i = 0; i < NUM_CHANNELS; i++)
-    pin2gpio[i] = 0;
+	pin2gpio[i] = 0;
 }
 
 static void
@@ -665,8 +651,8 @@ init_pwm(void){
 static void
 init_channel_pwm(void)
 {
-    printf("Initializing Channels...\n");
-    int i;
+	printf("Initializing Channels...\n");
+	int i;
 	for (i = 0; i < NUM_CHANNELS; i++)
 		channel_pwm[i] = 0;
 }
@@ -692,13 +678,13 @@ go_go_go(void)
 		n = sscanf(lineptr, "%d=%f%c", &servo, &value, &nl);
 		if (n !=3 || nl != '\n') {
 			//fprintf(stderr, "Bad input: %s", lineptr);
-      n = sscanf(lineptr, "release %d", &servo);
-      if (n != 1 || nl != '\n') {
-        fprintf(stderr, "Bad input: %s", lineptr);
-      } else {
-        // Release Pin from pin2gpio array if the release command is received.
-        release_pwm(servo);
-      }
+	  n = sscanf(lineptr, "release %d", &servo);
+	  if (n != 1 || nl != '\n') {
+		fprintf(stderr, "Bad input: %s", lineptr);
+	  } else {
+		// Release Pin from pin2gpio array if the release command is received.
+		release_pwm(servo);
+	  }
 		} else if (servo < 0){ // removed servo validation against CHANNEL_NUM no longer needed since now we used real GPIO names
 			fprintf(stderr, "Invalid channel number %d\n", servo);
 		} else if (value < 0 || value > 1) {
@@ -777,9 +763,9 @@ int mbox_open() {
    // open a char device file used for communicating with kernel mbox driver
    file_desc = open(DEVFILE_MBOX, 0);
    if (file_desc < 0) {
-      printf("Can't open device file: %s\n", DEVFILE_MBOX);
-      printf("Try creating a device file with: sudo mknod %s c %d 0\n", DEVFILE_MBOX, MAJOR_NUM);
-      exit(-1);
+	  printf("Can't open device file: %s\n", DEVFILE_MBOX);
+	  printf("Try creating a device file with: sudo mknod %s c %d 0\n", DEVFILE_MBOX, MAJOR_NUM);
+	  exit(-1);
    }
    return file_desc;
 }
@@ -810,20 +796,20 @@ main(int argc, char **argv)
 	clk_reg = map_peripheral(CLK_BASE, CLK_LEN);
 	gpio_reg = map_peripheral(GPIO_BASE, GPIO_LEN);
 
-    /* Use the mailbox interface to the VC to ask for physical memory */
-    unlink(DEVFILE_MBOX);
-    if (mknod(DEVFILE_MBOX, S_IFCHR|0600, makedev(MAJOR_NUM, 0)) < 0)
-        fatal("Failed to create mailbox device\n");
-    mbox.handle = mbox_open();
-    if (mbox.handle < 0)
-        fatal("Failed to open mailbox\n");
-    mbox.mem_ref = mem_alloc(mbox.handle, NUM_PAGES * PAGE_SIZE, PAGE_SIZE, mem_flag);
-    /* TODO: How do we know that succeeded? */
-    printf("mem_ref %u\n", mbox.mem_ref);
-    mbox.bus_addr = mem_lock(mbox.handle, mbox.mem_ref);
-    printf("bus_addr = %#x\n", mbox.bus_addr);
-    mbox.virt_addr = mapmem(BUS_TO_PHYS(mbox.bus_addr), NUM_PAGES * PAGE_SIZE);
-    printf("virt_addr %p\n", mbox.virt_addr);
+	/* Use the mailbox interface to the VC to ask for physical memory */
+	unlink(DEVFILE_MBOX);
+	if (mknod(DEVFILE_MBOX, S_IFCHR|0600, makedev(MAJOR_NUM, 0)) < 0)
+		fatal("Failed to create mailbox device\n");
+	mbox.handle = mbox_open();
+	if (mbox.handle < 0)
+		fatal("Failed to open mailbox\n");
+	mbox.mem_ref = mem_alloc(mbox.handle, NUM_PAGES * PAGE_SIZE, PAGE_SIZE, mem_flag);
+	/* TODO: How do we know that succeeded? */
+	printf("mem_ref %u\n", mbox.mem_ref);
+	mbox.bus_addr = mem_lock(mbox.handle, mbox.mem_ref);
+	printf("bus_addr = %#x\n", mbox.bus_addr);
+	mbox.virt_addr = mapmem(BUS_TO_PHYS(mbox.bus_addr), NUM_PAGES * PAGE_SIZE);
+	printf("virt_addr %p\n", mbox.virt_addr);
 
 	if ((unsigned long)mbox.virt_addr & (PAGE_SIZE-1))
 		fatal("pi-blaster: Virtual address is not page aligned\n");
@@ -831,10 +817,10 @@ main(int argc, char **argv)
 	init_ctrl_data();
 	init_hardware();
 	init_channel_pwm();
-  // Init pin2gpio array with 0/false values to avoid locking all of them as PWM.
+	// Init pin2gpio array with 0/false values to avoid locking all of them as PWM.
 	init_pin2gpio();
-  // Only calls update_pwm after ctrl_data calculates the pin mask to unlock all pins on start.
-  init_pwm();
+	// Only calls update_pwm after ctrl_data calculates the pin mask to unlock all pins on start.
+	init_pwm();
 
 	unlink(DEVFILE);
 	if (mkfifo(DEVFILE, 0666) < 0)
@@ -845,6 +831,7 @@ main(int argc, char **argv)
 	if (daemon(0,1) < 0)
 		fatal("pi-blaster: Failed to daemonize process: %m\n");
 
+	printf("Initialisation finished, pi-blaster now running as daemon, waiting for input on %s\n", DEVFILE);
 	go_go_go();
 
 	return 0;


### PR DESCRIPTION
fixes #33 

The basic logic was merged from @richardghirst s ServoBlaster fix for Pi2 but adapted where it seemed nicer/more clear to me...

- use mbox commands to allocate and then mmap memory areas for the DMA ControlBlocks and Sample Data
- add mbox command to read the firmware/board revision
- detect the board model from the mbox data, not by reading /proc/cpu (this is different from the ServoBlaster code but to me seems cleaner and more sustainable for future models)
- since Pi1 and Pi2 use different base adresses for mapping peripherals (DMA, PWM, PCM, CLK registers) in virtual memory, detect the model at runtime and set the periph_virt_base  accordingly
- some debugging (printf) code added to dump the register/control block and sample data state... only works if -DDEBUG is enabled in Makefile.am
- fix a problem calculating the physical fifo address from PWM/PCM signal for the DMA Wait Commands, this worked by chance on the Pi1 since the peripheral base was ORed out in the calculation but the different peripheral base for Pi2 was not (this caused most of the delay and cost me lots of grey hair finding a single bit difference in the address ;))
- use DMA channel 14 by default,  since DMA channel 0 causes problems with X

Let's start discussing :D 
