### PR TITLE
add Type=forking to systemd service file

### DIFF
--- a/pi-blaster.service
+++ b/pi-blaster.service
@@ -4,6 +4,7 @@ Description="Daemon for PWM control of the Raspberry PI GPIO pins"
 [Service]
 ExecStart=/usr/sbin/pi-blaster
 ExecReload=/bin/kill -s HUP $MAINPID
+Type=forking
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since pi-blaster is forking systemd needs to know about that. Or else the service will be considered failed and can't be used properly