### PR TITLE
handle install-data-hook when cross compile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ else
 init_ddir = $(sysconfdir)/init.d
 init_d_SCRIPTS = pi-blaster.boot.sh
 
+if !CROSS_COMPILING
 install-data-hook:
 	update-rc.d pi-blaster.boot.sh defaults
 	$(init_ddir)/pi-blaster.boot.sh start
@@ -20,4 +21,5 @@ install-data-hook:
 uninstall-hook:
 	update-rc.d pi-blaster.boot.sh remove
 	killall pi-blaster
-endif
+endif # !CROSS_COMPILING
+endif # !HAVE_SYSTEMD

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,7 @@ if test "x$with_systemdsystemunitdir" != xno; then
  AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 fi
 AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ])
+AM_CONDITIONAL(CROSS_COMPILING, [test x"$cross_compiling" = x"yes" ])
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
Avoid doing 'install-data-hook' when cross compiling since it isn't
suitable to update rc.d or run the service when cross
compiling.

Signed-off-by: Petter Mabäcker <petter@technux.se>