### PR TITLE
Make /etc/default/pi-blaster optional for systemd service

### DIFF
--- a/debian/pi-blaster.service
+++ b/debian/pi-blaster.service
@@ -2,7 +2,7 @@
 Description=Daemon for PWM control of the Raspberry Pi GPIO pins
 
 [Service]
-EnvironmentFile=/etc/default/pi-blaster
+EnvironmentFile=-/etc/default/pi-blaster
 User=root
 ExecStart=/usr/sbin/pi-blaster $DAEMON_OPTS
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
This change makes environment file `/etc/default/pi-blaster` optional for systemd service, so it won't refuse to start if the file does not exist.

This fixes issues #72, #68 and partially #71