### PR TITLE
adds CM3 support

### DIFF
--- a/pi-blaster.c
+++ b/pi-blaster.c
@@ -221,6 +221,7 @@ V revision (0-15)
 #define BOARD_REVISION_TYPE_ALPHA (5 << 4)
 #define BOARD_REVISION_TYPE_PI3_B (8 << 4)
 #define BOARD_REVISION_TYPE_CM (6 << 4)
+#define BOARD_REVISION_TYPE_CM3 (10 << 4)
 #define BOARD_REVISION_REV_MASK (0xF)
 
 
@@ -381,6 +382,8 @@ get_model(unsigned mbox_board_rev)
 		if ((mbox_board_rev & BOARD_REVISION_TYPE_MASK) == BOARD_REVISION_TYPE_PI2_B) {
 			board_model = 2;
 		} else if ((mbox_board_rev & BOARD_REVISION_TYPE_MASK) == BOARD_REVISION_TYPE_PI3_B) {
+			board_model = 3;
+		} else if ((mbox_board_rev & BOARD_REVISION_TYPE_MASK) == BOARD_REVISION_TYPE_CM3) {
 			board_model = 3;
 		} else {
 			// no Pi 2, we assume a Pi 1


### PR DESCRIPTION
The new compute model 3 has its own board revision, which needs to be mapped to the pi 3 b model. 

Here an example of the CM3 board revision. 
MBox Board Revision: 0xa220a0