### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM arm32v6/alpine as builder
+RUN apk add --update build-base autoconf automake linux-headers
+ADD . /pi-blaster
+WORKDIR /pi-blaster
+RUN ./autogen.sh
+RUN ./configure
+RUN make
+
+FROM arm32v6/alpine
+COPY --from=builder /pi-blaster/pi-blaster .
+CMD ["./pi-blaster", "-D"]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ And to uninstall, simply run:
 This will stop pi-blaster and prevent it from starting automatically on the next
 reboot.
 
+### Install with docker
+
+If you have docker on your RPi, you can run this image
+
+```bash
+docker run -it --privileged --rm -v /dev:/dev sarfata/pi-blaster
+```
+
+Or build from source in git repo
+
+```bash
+docker build -t pib .
+
+docker run -it --privileged --rm -v /dev:/dev pib
+```
+
 ## How to use
 
 pi-blaster creates a special file (FIFO) in `/dev/pi-blaster`. Any application


### PR DESCRIPTION
with multistage-build docker images size 3.83MB

build this
```
docker build -t pib .
```

run this
```
docker run -it --privileged --rm -v /dev:/dev pib
```

check this
```
echo "17=1" > /dev/pi-blaster
```

work on Hypriot hypriotos-rpi-v1.7.1 and raspberry pi 2b plus