### PR TITLE
pi-blaster: Include sys/sysmacros.h for makedev()

### DIFF
--- a/pi-blaster.c
+++ b/pi-blaster.c
@@ -41,6 +41,7 @@ static char VERSION[] = "SNAPSHOT";
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include "mailbox.h"


### PR DESCRIPTION
In glibc 2.28+ this header is not included indirectly anymore

fixes

ld: pi-blaster.o: in function `mbox_open':
pi-blaster.c:(.text+0x28): undefined reference to `makedev'
collect2: error: ld returned 1 exit status

Signed-off-by: Khem Raj <raj.khem@gmail.com>