### PR TITLE
Do not remove released pin from known pins

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([pi-blaster], [0.1.2])
+AC_INIT([pi-blaster], [0.1.3])
 AC_CONFIG_SRCDIR([pi-blaster.c])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE

--- a/pi-blaster.c
+++ b/pi-blaster.c
@@ -554,19 +554,6 @@ release_pin(int pin)
 {
   if (is_known_pin(pin)){
 	release_pin2gpio(pin);
-	int i;
-	for (i = 0; i < num_channels; i++) {
-		if (known_pins[i] == pin)
-		{
-			int j;
-			for (j = i; j < num_channels - 1; j++) {
-				known_pins[j] = known_pins[j + 1];
-			}
-			known_pins[num_channels] = 0;
-			num_channels--;
-			break;
-		}
-	}
   }else{
 	fprintf(stderr, "GPIO %d is not enabled for pi-blaster\n", pin);
   }


### PR DESCRIPTION
This is a fix for issue #74 
Once the pin is removed from the list of known pins, it cannot be reused.
However this removal was clearly intentional, and I don't know why. Am I missing something?



