### PR TITLE
Fix pi-blaster on the Raspberry Pi 3A+

### DIFF
--- a/pi-blaster.c
+++ b/pi-blaster.c
@@ -229,6 +229,7 @@ V revision (0-15)
 #define BOARD_REVISION_TYPE_ALPHA (5 << 4)
 #define BOARD_REVISION_TYPE_PI3_B (8 << 4)
 #define BOARD_REVISION_TYPE_PI3_BP (0xD << 4)
+#define BOARD_REVISION_TYPE_PI3_AP (0x7 << 5)
 #define BOARD_REVISION_TYPE_CM (6 << 4)
 #define BOARD_REVISION_TYPE_CM3 (10 << 4)
 #define BOARD_REVISION_REV_MASK (0xF)
@@ -379,6 +380,8 @@ static void get_model(unsigned mbox_board_rev) {
     } else if ((mbox_board_rev & BOARD_REVISION_TYPE_MASK) == BOARD_REVISION_TYPE_PI3_B) {
       board_model = 3;
     } else if ((mbox_board_rev & BOARD_REVISION_TYPE_MASK) == BOARD_REVISION_TYPE_PI3_BP) {
+      board_model = 3;
+    } else if ((mbox_board_rev & BOARD_REVISION_TYPE_MASK) == BOARD_REVISION_TYPE_PI3_AP) {
       board_model = 3;
     } else if ((mbox_board_rev & BOARD_REVISION_TYPE_MASK) == BOARD_REVISION_TYPE_CM3) {
       board_model = 3;


### PR DESCRIPTION
This checks against the type mask of the 3A+ and sets the model accordingly.